### PR TITLE
Allow delayed-req to be composed with other request wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Simple module wrapping the "request" module to add some random delay between req
 ## Example
 
 ```javascript
-var Request = require('delayed-request');
+var Request = require('delayed-request')(require('request'));
 
 var request = new Request({
 	debug: true, // Optional, output delay to console

--- a/example.js
+++ b/example.js
@@ -1,19 +1,20 @@
-var Request = require('./lib/Request');
+var request = require('request');
+var Request = require('./lib/Request')(request);
 
 var request = new Request({
-	debug: true, // Optional, output delay to console
-	delayMin: 1000,
-	delayMax: 3000
+  debug: true, // Optional, output delay to console
+  delayMin: 1000,
+  delayMax: 3000
 });
 
 console.log('Run first request');
 
-request.run('http://www.google.com', function(err, response) {
-	console.log('First request response received');
+request.run('http://www.google.com', function (err, response) {
+  console.log('First request response received');
 });
 
 console.log('Run second request');
 
-request.run('http://www.google.com', function(err, response) {
-	console.log('Second request response received');
+request.run('http://www.google.com', function (err, response) {
+  console.log('Second request response received');
 });

--- a/lib/Request.js
+++ b/lib/Request.js
@@ -1,49 +1,51 @@
-var _request = require('request');
+'use strict';
 
-var Request = function(options) {
-	options = options || {};
+module.exports = function (_request) {
+    var Request = function (options) {
+        options = options || {};
 
-	// Default values
-	this._delayMin = options.delayMin || 1000;
-	this._delayMax = options.delayMax || 3000;
-    this._debug = options.debug || false;
-	this._lastReqTime = 0;
+        // Default values
+        this._delayMin = options.delayMin || 1000;
+        this._delayMax = options.delayMax || 3000;
+        this._debug = options.debug || false;
+        this._lastReqTime = 0;
+    };
+
+    Request.prototype._log = function (message) {
+        if (this._debug) {
+            console.log(message);
+        }
+    };
+
+    Request.prototype.run = function (options, callback) {
+        var _this = this;
+
+        // Compute time from previous request & generate a random delay
+        var timeSincePrevReq = new Date().getTime() - this._lastReqTime;
+        var delay = this._randomDelay();
+
+        // Send or delay the request if the delay since previous is too small
+        if (timeSincePrevReq < delay) {
+            var waitingTime = delay - timeSincePrevReq;
+
+            _this._log('Wait ' + waitingTime + 'ms before request.');
+
+            setTimeout(function () {
+                _this._execute(options, callback);
+            }, waitingTime);
+        } else {
+            _this._execute(options, callback);
+        }
+    };
+
+    Request.prototype._execute = function (options, callback) {
+        _request(options, callback);
+        this._lastReqTime = new Date().getTime();
+    };
+
+    Request.prototype._randomDelay = function () {
+        return Math.floor(Math.random() * (this._delayMax - this._delayMin + 1) + this._delayMin)
+    };
+
+    return Request;
 };
-
-Request.prototype._log = function(message) {
-    if(this._debug) {
-        console.log(message);
-    }
-};
-
-Request.prototype.run = function(options, callback) {
-	var _this = this;
-
-	// Compute time from previous request & generate a random delay
-    var timeSincePrevReq = new Date().getTime() - this._lastReqTime;
-    var delay = this._randomDelay();
-
-    // Send or delay the request if the delay since previous is too small
-    if(timeSincePrevReq < delay) {
-        var waitingTime = delay-timeSincePrevReq;
-
-        _this._log('Wait '+ waitingTime +'ms before request.');
-
-    	setTimeout(function() {
-    		_this._execute(options, callback);
-    	}, waitingTime);
-    } else {
-    	_this._execute(options, callback);
-    }
-};
-
-Request.prototype._execute = function(options, callback) {
-	_request(options, callback);
-    this._lastReqTime = new Date().getTime();
-};
-
-Request.prototype._randomDelay = function() {
-	return Math.floor(Math.random()*(this._delayMax-this._delayMin+1)+this._delayMin)
-};
-
-module.exports = Request;

--- a/package.json
+++ b/package.json
@@ -16,12 +16,13 @@
     "delayed",
     "http"
   ],
-  "dependencies": {
-    "request": "~2.34.0"
-  },
+  "dependencies": {},
   "author": "Leeroy Brun <leeroy.brun@gmail.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/leeroybrun/node-delayed-request/issues"
+  },
+  "devDependencies": {
+    "request": "^2.64.0"
   }
 }


### PR DESCRIPTION
node-delayed-request now does not include request dep, allowing it to be composed with other request wrapper, like node-request-reply, fixes FGRibreau/node-request-retry/issues/18
